### PR TITLE
Prompt Engineering hmwk 

### DIFF
--- a/Demos/Module2/weather_consumer.py
+++ b/Demos/Module2/weather_consumer.py
@@ -1,0 +1,46 @@
+import requests
+from pprint import pprint
+
+url = "http://api.weatherapi.com/v1/current.json"
+headers = {"key": "915f3e2a470f467abb5210346252603"}
+
+def handle_api(url, headers, params):
+    try:
+        response = requests.get(url, headers = headers, params = params)
+        if response.status_code == 200:
+            print("the GET request worked :)")
+            #pprint(response.json())
+            return response.json()
+        else: #ie if the response isnt a success
+            print(f"GET request failed :( {response.status_code}")
+            return False
+    except requests.exceptions.RequestException as exc:
+        print(f"the error that occurred: {exc}")
+
+def display_info(result):
+    temp_f = result["current"]["temp_f"]
+    humidity = result["current"]["humidity"]
+    condition = result["current"]["condition"]
+    print(f"Temperature: {temp_f}°F")
+    print(f"Humidity: {humidity}")
+    print(f"Condition: {condition}")
+
+def main():
+    city = input("enter the name of city ")
+    if city:
+        params = {"q": city,
+              "aqi": "no"}
+        result = handle_api(url, headers, params)
+        if result != False: #ie if it holds the response data bc city was accepted
+            display_info(result)
+    else:
+        print("enter a valid city name")
+
+if __name__ == '__main__':
+    main()
+
+
+
+
+
+

--- a/Demos/Module3/generate_gpa_unittests.py
+++ b/Demos/Module3/generate_gpa_unittests.py
@@ -1,0 +1,37 @@
+"""
+This test code was generated from a request interacting with openAI API libraries in part4() of generate_students_report.py
+
+These unittests confirm that:
+there are 3 students,
+that each student has a name, grades, and gpa
+that the grades are all int type only
+"""
+import unittest
+
+#To run this unittest on the third generated code:
+#from Demos.Module3.generated_gpa_pt3 import student_data
+
+student_data = {
+    1: {"name": "Alice", "grades": [85, 90, 88], "gpa": round(sum([85, 90, 88])/len([85, 90, 88])/25, 2)},
+    2: {"name": "Bob", "grades": [75, 80, 82], "gpa": round(sum([75, 80, 82])/len([75, 80, 82])/25, 2)},
+    3: {"name": "Charlie", "grades": [90, 95, 92], "gpa": round(sum([90, 95, 92])/len([90, 95, 92])/25, 2)}  }
+
+class TestStudentDictionary(unittest.TestCase):
+  def test_number_of_student_data(self):
+      self.assertEqual(len(student_data), 3)
+
+  def test_student_details(self):
+      for student_id, student_info in student_data.items():
+          self.assertIn("name", student_info)
+          self.assertIn("grades", student_info)
+          self.assertIn("gpa", student_info)
+
+  def test_grade_type(self):
+      for student_id, student_info in  student_data.items():
+          self.assertTrue(all(isinstance(grade, int) for grade in
+student_info["grades"]))
+
+if __name__ ==  '__main__'   :
+  unittest.main()
+
+

--- a/Demos/Module3/generate_students_report.py
+++ b/Demos/Module3/generate_students_report.py
@@ -1,0 +1,73 @@
+"""
+This is an exercise to explore how different prompts affects the responses generated
+This code interacts with OpenAI's API directories to generate multiple code that calculates students' gpa
+"""
+
+from src.open_api_client import get_openai_client
+from pprint import pprint
+
+client = get_openai_client()
+pprint(vars(client))
+system_prompts = []
+
+def makeRequestAPI(user_input: str):
+    """
+    Creates a request to OpenAI from the given prompt and prints output in terminal
+   Args:
+       user_input str: string of input prompt
+   """
+    global completion
+    completion = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "user", "content": user_input}
+        ]
+    )
+    # Output the response
+    pprint(completion)
+    pprint(completion.choices[0].message.content)
+
+
+def part1():
+    input1 = """Create a Python dictionary where each student ID maps to another dictionary containing:
+    "name": Student’s name (string)
+    "grades": A list of grades (integers).
+    "gpa": The GPA, calculated as (sum of grades / number of grades) / 25, rounded to two decimal places."""
+    makeRequestAPI(input1)
+def part2():
+    input2 = """Create a Python dictionary where each student ID maps to another dictionary containing:
+"name": Student’s name (string)
+"grades": A list of grades (integers).
+"gpa": The GPA, calculated as (sum of grades / number of grades) / 25, rounded to two decimal places.
+Use dictionary comprehension to construct the dictionary."""
+    makeRequestAPI(input2)
+def part3():
+    input3 = """Create a Python dictionary where each student ID maps to another dictionary containing:
+    "name": Student’s name (string)
+    "grades": A list of grades (integers).
+    "gpa": The GPA, calculated as (sum of grades / number of grades) / 25, rounded to two decimal places.
+    Use dictionary comprehension, and then format the output using print() so that the student data is displayed in a well-structured format."""
+    makeRequestAPI(input3)
+def part4():
+    input4 = """Create a Python dictionary where each student ID maps to another dictionary containing:
+"name": Student’s name (string)
+"grades": A list of grades (integers).
+"gpa": The GPA, calculated as (sum of grades / number of grades) / 25, rounded to two decimal places.
+Use dictionary comprehension to create it.
+Then, write unit tests using unittest to verify that:
+The dictionary contains the correct number of students.
+Each student has a "name", "grades", and "gpa".
+The "grades" list contains only integers.
+Ensure test coverage using IntelliJ’s built-in coverage tool."""
+    makeRequestAPI(input4)
+
+def main():
+    part1()
+    part2()
+    part3()
+    part4()
+
+if __name__ == '__main__':
+    main()
+
+

--- a/Demos/Module3/generate_students_report.py
+++ b/Demos/Module3/generate_students_report.py
@@ -16,7 +16,6 @@ def makeRequestAPI(user_input: str):
    Args:
        user_input str: string of input prompt
    """
-    global completion
     completion = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[

--- a/Demos/Module3/generated_gpa_pt3.py
+++ b/Demos/Module3/generated_gpa_pt3.py
@@ -1,0 +1,14 @@
+"""
+This test code was generated from a request interacting with openAI API libraries in part3() of generate_students_report.py
+Instructions were to create the code with dictionary comprehension and formatted for readability
+"""
+student_data = {101: {"name": "Alice", "grades": [85, 90, 92, 88], "gpa": round(sum([85, 90, 92, 88]) / len([85, 90, 92, 88]) / 25, 2)},
+ 102: {"name": "Bob", "grades": [78, 82, 80, 85], "gpa": round(sum([78, 82, 80, 85]) / len([78, 82, 80, 85]) / 25, 2)},
+ 103: {"name": "Charlie", "grades": [92, 94, 90, 88], "gpa": round(sum([92, 94, 90, 88]) / len([92, 94, 90, 88]) / 25, 2)}}
+
+for student_id, student_info in student_data.items():
+    print(f"Student ID: {student_id}")
+    print(f"Name: {student_info['name']}")
+    print(f"Grades: {student_info['grades']}")
+    print(f"GPA: {student_info['gpa']}")
+    print()

--- a/Demos/Module3/openai code ouputs
+++ b/Demos/Module3/openai code ouputs
@@ -5,7 +5,7 @@ Part1: Create Basic Dictionary for GPA Calculation
 
 
 Part2: Using Dictionary Comprehension
-student_data = { 
+students = {
 "123": {"name": "Alice", "grades": [80, 85, 90], "gpa": round(sum([80, 85, 90]) / len([80, 85, 90]) / 25, 2)}, 
 "234": {"name": "Bob", "grades": [75, 80, 85], "gpa": round(sum([75, 80, 85]) / len([75, 80, 85]) / 25, 2)}, 
 "345": {"name": "Charlie", "grades": [85, 90, 95], "gpa": round(sum([85, 90, 95]) / len([85, 90, 95]) / 25, 2)} }  
@@ -13,7 +13,7 @@ student_data = {
 # Using dictionary comprehension 
 student_ids = ["123", "234", "345"] 
 
-student_data = {sid: {"name": student_data[sid]["name"], "grades": student_data[sid]["grades"], "gpa": student_data[sid]["gpa"]}
+student_data = {sid: {"name": students[sid]["name"], "grades": students[sid]["grades"], "gpa": students[sid]["gpa"]}
 for sid in student_ids}
 print(student_data)
 

--- a/Demos/Module3/openai code ouputs
+++ b/Demos/Module3/openai code ouputs
@@ -1,0 +1,59 @@
+Part1: Create Basic Dictionary for GPA Calculation
+1234: {         "name": "Alice",         "grades": [85, 90, 88, 92, 87],         "gpa": round(sum([85, 90, 88, 92, 87]) / len([85, 90, 88, 92, 87]) / 25, 2)     }, 
+5678: {         "name": "Bob",         "grades": [78, 82, 80, 85, 79],         "gpa": round(sum([78, 82, 80, 85, 79]) / len([78, 82, 80, 85, 79]) / 25, 2)     }, 
+9101: {         "name": "Charlie",         "grades": [92, 95, 91, 89, 93],         "gpa": round(sum([92, 95, 91, 89, 93]) / len([92, 95, 91, 89, 93]) / 25, 2)     } }'
+
+
+Part2: Using Dictionary Comprehension
+student_data = { 
+"123": {"name": "Alice", "grades": [80, 85, 90], "gpa": round(sum([80, 85, 90]) / len([80, 85, 90]) / 25, 2)}, 
+"234": {"name": "Bob", "grades": [75, 80, 85], "gpa": round(sum([75, 80, 85]) / len([75, 80, 85]) / 25, 2)}, 
+"345": {"name": "Charlie", "grades": [85, 90, 95], "gpa": round(sum([85, 90, 95]) / len([85, 90, 95]) / 25, 2)} }  
+
+# Using dictionary comprehension 
+student_ids = ["123", "234", "345"] 
+
+student_data = {sid: {"name": student_data[sid]["name"], "grades": student_data[sid]["grades"], "gpa": student_data[sid]["gpa"]}
+for sid in student_ids}
+print(student_data)
+
+
+Part3: Formatting the Output for Readability
+ Create a Python dictionary using dictionary comprehension '
+ student_data = {
+ 101: {"name": "Alice", "grades": [85, 90, 92, 88], "gpa": round(sum([85, 90, 92, 88]) / len([85, 90, 92, 88]) / 25, 2)}, 
+ 102: {"name": "Bob", "grades": [78, 82, 80, 85], "gpa": round(sum([78, 82, 80, 85]) / len([78, 82, 80, 85]) / 25, 2)}, 
+ 103: {"name": "Charlie", "grades": [92, 94, 90, 88], "gpa": round(sum([92, 94, 90, 88]) / len([92, 94, 90, 88]) / 25, 2)} }  
+ for student_id, student_info in student_data.items(): 
+ print(f"Student ID: {student_id}") 
+ print(f"Name: {student_info[\'name\']}") 
+ print(f"Grades: {student_info[\'grades\']}") 
+ print(f"GPA: {student_info[\'gpa\']}") 
+ print()'
+
+
+
+Part4: Generating Unit Tests with Coverage
+ student_data = {
+ 1: {"name": "Alice", "grades": [85, 90, 88], "gpa": round(sum([85, 90, 88])/len([85, 90, 88])/25, 2)},
+ 2: {"name": "Bob", "grades": [75, 80, 82], "gpa": round(sum([75, 80, 82])/len([75, 80, 82])/25, 2)},      
+ 3: {"name": "Charlie", "grades": [90, 95, 92], "gpa": round(sum([90, 95, 92])/len([90, 95, 92])/25, 2)}  } 
+    
+ import unittest    
+ 
+ class Test  student_data(unittest.TestCase):        
+    def test_num_  student_data(self):          
+        self.assertEqual(len(  student_data), 3)     
+           
+    def test_student_keys(self):          
+    for student_id, student_info in   student_data.items():              
+        self.assertIn("name", student_info)              
+        self.assertIn("grades", student_info)              
+        self.assertIn("gpa", student_info)     
+           
+    def test_grades_type(self):          
+        for student_id, student_info in   student_data.items():              
+            self.assertTrue(all(isinstance(grade, int) for grade in student_info["grades"]))    
+ 
+ if __name__ == "__main__":    
+ unittest.main()


### PR DESCRIPTION
Output of prompt1:  printed nothing
Output of prompt2: {'123': {'name': 'Alice', 'grades': [80, 85, 90], 'gpa': 3.4}, '234': {'name': 'Bob', 'grades': [75, 80, 85], 'gpa': 3.2}, '345': {'name': 'Charlie', 'grades': [85, 90, 95], 'gpa': 3.6}}
Output of prompt3: Student ID: 101
Name: Alice
Grades: [85, 90, 92, 88]
GPA: 3.55

Student ID: 102
Name: Bob
Grades: [78, 82, 80, 85]
GPA: 3.25

Student ID: 103
Name: Charlie
Grades: [92, 94, 90, 88]
GPA: 3.64

The codes generated by openAI requests became more sophisticated with the progressively more specific wording. The different prompts directly impacted how openAI wrote its code to print progressively more formatted student data for readability. To get meaningful output, one needs to be specific in how they instruct openAI to generate and format its code (ie familiarize oneself with keywords to direct the model to create usable code that will do what you actually want it to).

Prompt4 generated unittests that passed with its generated sample data and when tested on prompt3's code.